### PR TITLE
Updates sample code in README to be runnable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-# ref: https://docs.travis-ci.com/user/languages/python
+dist: xenial
+sudo: false
 language: python
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
-  #- "3.5-dev" # 3.5 development branch
-  #- "nightly" # points to the latest development branch e.g. 3.6-dev
-# command to install dependencies
-install: "pip install -r requirements.txt"
-# command to run tests
-script: nosetests
+  - "3.6"
+  - "3.7"
+install: pip install -r requirements.txt
+script: tox

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ intrinio_sdk.ApiClient().configuration.api_key['api_key'] = 'YOUR_API_KEY'
 company_api = intrinio_sdk.CompanyApi()
 
 try:
-    api_response = company_api.filter_companies()
+    api_response = company_api.get_company('AAPL')
     pprint(api_response)
 except ApiException as e:
-    print("Exception when calling CompanyApi->filter_companies: %s\n" % e)
+    print("Exception when calling CompanyApi.get_company: %s\n" % e)
 ```
 
 ## Documentation for API Endpoints

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
+tox-travis


### PR DESCRIPTION
The example code in the README uses a `filter_companies` method that does not seem to be defined anywhere. This PR replaces that undefined method with a simple call to `get_company` so that users can quickly and easily have a running code sample to test their installation of the python SDK.