### PR TITLE
Updates to travis-ci config to use tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-# ref: https://docs.travis-ci.com/user/languages/python
+dist: xenial
+sudo: false
 language: python
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
-  #- "3.5-dev" # 3.5 development branch
-  #- "nightly" # points to the latest development branch e.g. 3.6-dev
-# command to install dependencies
-install: "pip install -r requirements.txt"
-# command to run tests
-script: nosetests
+  - "3.6"
+  - "3.7"
+install: pip install -r requirements.txt
+script: tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
+tox-travis


### PR DESCRIPTION
This project appears to already use tox for running tests in multiple
environments, so this change makes use of the tox-travis module so
that travis-ci builds can easily call into tox to run the test suite
instead of maintaining two callpaths into the nosetest based test suite.

This commit forces using Xenial on travis-ci so as to support python 3.7

Signed-off-by: zachwick <zach@zachwick.com>