### PR TITLE
Resolve DeprecationWarning When Accessing Response Headers

### DIFF
--- a/intrinio_sdk/rest.py
+++ b/intrinio_sdk/rest.py
@@ -43,7 +43,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""


### PR DESCRIPTION
A `DeprecationWarning` is raised when `HTTPResponse.getheaders()` is called. The method is deprecated and will be removed in `urllib3 v2.1.0`. 

This updated file accesses `HTTPResponse.headers` directly as-recommended.

Tested/validated with end-of-day options API