### PR TITLE
Clean up DeprecationWarnings for invalid escape sequences in regex

### DIFF
--- a/intrinio_sdk/api_client.py
+++ b/intrinio_sdk/api_client.py
@@ -286,12 +286,12 @@ class ApiClient(object):
 
         if type(klass) == str:
             if klass.startswith('list['):
-                sub_kls = re.match('list\[(.*)\]', klass).group(1)
+                sub_kls = re.match(r'list\[(.*)]', klass).group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
             if klass.startswith('dict('):
-                sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)
+                sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in six.iteritems(data)}
 


### PR DESCRIPTION
The following deprecation warnings were raised:
```
intrinio_sdk/api_client.py:289: DeprecationWarning: invalid escape sequence 
  '\\['\n sub_kls = re.match('list\\[(.*)\\]', klass).group(1)\n"}
intrinio_sdk/api_client.py:294: DeprecationWarning: invalid escape sequence 
  '\\('\n sub_kls = re.match('dict\\(([^,]*), (.*)\\)', klass).group(2)\n"}
```
These warnings occurred because non-raw strings were used, causing Python to misinterpret the escape sequences. Switching to raw string literals (e.g., `r'list\[(.*)]'` and `r'dict\(([^,]*), (.*)\)')` resolves the warnings.

Tested by running all 555 tests in `test/` successfully and with this code which compares old and revised code:
```python
import re
# List regex patterns:
pattern_list_raw = re.compile(r'list\[(.*)\]')
pattern_list_non_raw = re.compile('list\[(.*)]')
list_test_cases = [
    ("list[int]", "int"),
    ("list[str]", "str"),
    ("list[MyClass]", "MyClass"),
    ("list[dict]", "dict"),
]
for test_input, expected in list_test_cases:
    match_raw = pattern_list_raw.match(test_input)
    match_non_raw = pattern_list_non_raw.match(test_input)
    assert match_raw is not None, f"Raw regex did not match input: {test_input}"
    assert match_non_raw is not None, f"Non‑raw regex did not match input: {test_input}"
    result_raw = match_raw.group(1)
    result_non_raw = match_non_raw.group(1)
    assert result_raw == expected, f"Raw regex expected '{expected}', got '{result_raw}' for {test_input}"
    assert result_non_raw == expected, f"Non‑raw regex expected '{expected}', got '{result_non_raw}' for {test_input}"
    assert result_raw == result_non_raw, f"Mismatch between raw and non‑raw for {test_input}"
# Dict regex patterns:
pattern_dict_raw = re.compile(r'dict\(([^,]*), (.*)\)')
pattern_dict_non_raw = re.compile('dict\(([^,]*), (.*)\)')
dict_test_cases = [
    ("dict(str, int)", ("str", "int")),
    ("dict(MyKey, MyValue)", ("MyKey", "MyValue")),
    ("dict(dict, list[str])", ("dict", "list[str]")),
]
for test_input, (expected_group1, expected_group2) in dict_test_cases:
    match_raw = pattern_dict_raw.match(test_input)
    match_non_raw = pattern_dict_non_raw.match(test_input)
    assert match_raw is not None, f"Raw regex did not match input: {test_input}"
    assert match_non_raw is not None, f"Non‑raw regex did not match input: {test_input}"
    result_group1_raw = match_raw.group(1)
    result_group2_raw = match_raw.group(2)
    result_group1_non_raw = match_non_raw.group(1)
    result_group2_non_raw = match_non_raw.group(2)
    assert result_group1_raw == expected_group1, (
        f"Raw regex group(1) expected '{expected_group1}', got '{result_group1_raw}' for {test_input}"
    )
    assert result_group2_raw == expected_group2, (
        f"Raw regex group(2) expected '{expected_group2}', got '{result_group2_raw}' for {test_input}"
    )
    assert result_group1_non_raw == expected_group1, (
        f"Non‑raw regex group(1) expected '{expected_group1}', got '{result_group1_non_raw}' for {test_input}"
    )
    assert result_group2_non_raw == expected_group2, (
        f"Non‑raw regex group(2) expected '{expected_group2}', got '{result_group2_non_raw}' for {test_input}"
    )
    assert (result_group1_raw, result_group2_raw) == (result_group1_non_raw, result_group2_non_raw), (
        f"Mismatch between raw and non‑raw regex results for {test_input}"
    )
print("All tests passed!")
```